### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Query OpenAI models directly from Claude using MCP protocol.
 
 ![preview](preview.png)
 
+<a href="https://glama.ai/mcp/servers/f7pt2hkdug"><img width="380" height="200" src="https://glama.ai/mcp/servers/f7pt2hkdug/badge" alt="OpenAI Server MCP server" /></a>
+
 ## Setup
 
 Add to `claude_desktop_config.json`:


### PR DESCRIPTION
This PR adds a badge for the OpenAI MCP Server server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/f7pt2hkdug

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.